### PR TITLE
Added Missing Steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ Pin.close(pin_8)
 * Need installed [Azure Sphere SDK](https://docs.microsoft.com/en-us/azure-sphere/install/install-sdk)
 * [Python 3](https://www.python.org/)
 * MAKE ... [I use from MinGW](http://www.mingw.org/)
+    * Select the mingw32-base-bin
+    * Add C:\MinGW\bin\ to your path
 * Download [micropython](https://github.com/micropython/micropython)
 * Move this folder **azure-minimal** to micropython/ports
 * Open folder **azure-minimal**
+* Install Platformio VSCode Extension
+https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide
+* Install Azure Shere Platorm for PlatformIO using these steps: https://github.com/Wiz-IO/platform-azure#platform-installation
 * Open **Makefile** and edit your paths [ CROSS_DIR, SYSROOT, PYTHON ]
-* Execute **make**
+* Execute **make** ex: `mingw32-make.exe`
 * Run PACK_IMAGE.BAT (edit path to **azsphere**)
 * Run UPLOAD.BAT (edit path to **azsphere**)
 


### PR DESCRIPTION
Adding some clarity to the steps and added some steps I found were missing.

1. Added a little clarity to what needs to be installed from MinGW since I had to figure it out
2. I was not able to get make to run at all without the PlatfomIO steps being completed.
3. Clarified the make command for MinGW since its not **make**.

I'm still not able to build successfully on Windows, but I wanted to capture these changes for now.